### PR TITLE
Ab test/agent action shadow

### DIFF
--- a/apps/scut-senior/api/src/scut_senior_api/agent_loop.py
+++ b/apps/scut-senior/api/src/scut_senior_api/agent_loop.py
@@ -19,6 +19,16 @@ ActionKind = Literal[
     "generate_answer",
     "finish",
 ]
+
+# Workflow is the hard boundary. Agent may choose a next step only from the
+# actions the selected workflow exposes; it never chooses a new workflow.
+WORKFLOW_ACTIONS: dict[str, frozenset[ActionKind]] = {
+    "knowledge_qa": frozenset({"retrieve", "retrieve_with_query_rewrite", "generate_answer", "finish"}),
+    "exam_review": frozenset({"retrieve", "retrieve_with_query_rewrite", "generate_answer", "finish"}),
+    "problem_tutor": frozenset({"retrieve", "retrieve_with_query_rewrite", "generate_answer", "finish"}),
+    "mistake_review": frozenset({"retrieve", "retrieve_with_query_rewrite", "generate_answer", "finish"}),
+    "temporary_material_reading": frozenset({"retrieve", "generate_answer", "finish"}),
+}
 EventKind = Literal[
     "decision_produced",
     "action_rejected",
@@ -50,7 +60,14 @@ ACTION_KINDS: frozenset[ActionKind] = frozenset(
 )
 
 
-def choose_next_action(state: "AgentState", *, phase: str) -> ActionKind:
+def action_allowed_for_workflow(workflow_type: str, action: ActionKind) -> bool:
+    """Return whether an Agent action stays inside the selected Workflow."""
+    return action in WORKFLOW_ACTIONS.get(workflow_type, frozenset())
+
+
+def choose_next_action(
+    state: "AgentState", *, phase: str, workflow_type: str = "knowledge_qa"
+) -> ActionKind:
     """Select one bounded action for the compatibility runtime path.
 
     This is deliberately a small policy, not a second planner: retrieval is
@@ -58,11 +75,20 @@ def choose_next_action(state: "AgentState", *, phase: str) -> ActionKind:
     decision adapter can feed the same allowlist and reducer events.
     """
     if phase == "retrieve" and state.retrieval_rounds == 0:
-        return "retrieve"
+        action = "retrieve"
+        if not action_allowed_for_workflow(workflow_type, action):
+            raise ValueError("workflow does not allow retrieval")
+        return action
     if phase == "retrieve_with_query_rewrite":
-        return "retrieve_with_query_rewrite"
+        action = "retrieve_with_query_rewrite"
+        if not action_allowed_for_workflow(workflow_type, action):
+            raise ValueError("workflow does not allow query rewrite retrieval")
+        return action
     if phase == "generate":
-        return "generate_answer"
+        action = "generate_answer"
+        if not action_allowed_for_workflow(workflow_type, action):
+            raise ValueError("workflow does not allow answer generation")
+        return action
     raise ValueError("unknown agent compatibility phase")
 
 

--- a/apps/scut-senior/api/src/scut_senior_api/agent_loop.py
+++ b/apps/scut-senior/api/src/scut_senior_api/agent_loop.py
@@ -9,7 +9,10 @@ introduced incrementally.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Literal
+from typing import Literal, Protocol
+
+from .ports import ConversationTurn, GeneratedAnswer, ModelGateway, RetrievedSource
+from .contracts import WorkflowRunRequest
 
 
 ActionKind = Literal[
@@ -63,6 +66,81 @@ ACTION_KINDS: frozenset[ActionKind] = frozenset(
 def action_allowed_for_workflow(workflow_type: str, action: ActionKind) -> bool:
     """Return whether an Agent action stays inside the selected Workflow."""
     return action in WORKFLOW_ACTIONS.get(workflow_type, frozenset())
+
+
+class AgentDecisionGateway(Protocol):
+    def decide(
+        self,
+        request: WorkflowRunRequest,
+        state: "AgentState",
+        phase: str,
+        *,
+        sources: list[RetrievedSource] | tuple[RetrievedSource, ...] = (),
+        history: tuple[ConversationTurn, ...] = (),
+    ) -> ActionKind: ...
+
+
+class RuleBasedAgentDecision:
+    """Deterministic fallback used when the model decision experiment is off."""
+
+    def decide(self, request, state, phase, *, sources=(), history=()) -> ActionKind:
+        return choose_next_action(state, phase=phase, workflow_type=request.workflow_type.value)
+
+
+def parse_model_action(raw: str, *, workflow_type: str) -> ActionKind | None:
+    """Parse a model's single-action response and apply the Workflow allowlist."""
+    normalized = raw.strip().lower().replace("`", "")
+    aliases: dict[str, ActionKind] = {
+        "retrieve": "retrieve",
+        "retrieve_with_query_rewrite": "retrieve_with_query_rewrite",
+        "query_rewrite": "retrieve_with_query_rewrite",
+        "ask_clarification": "ask_clarification",
+        "generate_answer": "generate_answer",
+        "finish": "finish",
+    }
+    for token in normalized.replace("\n", " ").split():
+        action = aliases.get(token.strip(" .,;:："))
+        if action is not None:
+            return action if action_allowed_for_workflow(workflow_type, action) else None
+    return None
+
+
+class ModelAgentDecision:
+    """Model-backed Action adapter with fail-closed Workflow validation.
+
+    The adapter is intentionally separate from answer generation. Providers
+    that cannot return a clean action fall back to the deterministic policy;
+    an unallowlisted action is never executed.
+    """
+
+    def __init__(self, model: ModelGateway, fallback: AgentDecisionGateway | None = None):
+        self.model = model
+        self.fallback = fallback or RuleBasedAgentDecision()
+
+    def decide(self, request, state, phase, *, sources=(), history=()) -> ActionKind:
+        decision_request = request.model_copy(
+            update={
+                "user_input": (
+                    "只输出一个允许的 Action 名称，不要解释。"
+                    "允许值：retrieve, retrieve_with_query_rewrite, "
+                    "ask_clarification, generate_answer, finish。"
+                    f"当前 Workflow={request.workflow_type.value}，阶段={phase}，"
+                    f"已检索轮次={state.retrieval_rounds}，已有证据数={len(sources)}。"
+                )
+            }
+        )
+        try:
+            generated: GeneratedAnswer = self.model.generate(
+                decision_request, list(sources), history
+            )
+            parsed = parse_model_action(
+                generated.repository_answer, workflow_type=request.workflow_type.value
+            )
+            if parsed is not None:
+                return parsed
+        except Exception:
+            pass
+        return self.fallback.decide(request, state, phase, sources=sources, history=history)
 
 
 def choose_next_action(

--- a/apps/scut-senior/api/src/scut_senior_api/agent_loop.py
+++ b/apps/scut-senior/api/src/scut_senior_api/agent_loop.py
@@ -98,11 +98,13 @@ def parse_model_action(raw: str, *, workflow_type: str) -> ActionKind | None:
         "generate_answer": "generate_answer",
         "finish": "finish",
     }
-    for token in normalized.replace("\n", " ").split():
-        action = aliases.get(token.strip(" .,;:："))
-        if action is not None:
-            return action if action_allowed_for_workflow(workflow_type, action) else None
-    return None
+    # Fail closed: accept a single token only. Explanatory model prose must
+    # never accidentally turn a mention of an Action into an executable one.
+    token = normalized.strip(" .,;:：")
+    action = aliases.get(token)
+    if action is None:
+        return None
+    return action if action_allowed_for_workflow(workflow_type, action) else None
 
 
 class ModelAgentDecision:

--- a/apps/scut-senior/api/src/scut_senior_api/config.py
+++ b/apps/scut-senior/api/src/scut_senior_api/config.py
@@ -46,6 +46,9 @@ class Settings:
     exam_review_plan_enabled: bool = True
     # Phase-two agent progress events are opt-in for old NDJSON clients.
     agent_event_stream_enabled: bool = False
+    # AB test only: model asks for the next bounded Action; invalid/unclear
+    # output falls back to the deterministic policy.
+    agent_decision_mode: Literal["rule", "model"] = "rule"
     # Iteration 7.5 (SOP §12A Group B): in-process periodic cleanup scheduler.
     # Decision gate confirmed form = in-process daemon thread for single-host
     # deployment; disabling restores startup/access-triggered cleanup only.
@@ -110,6 +113,7 @@ class Settings:
             agent_event_stream_enabled=_env_bool(
                 "SCUT_SENIOR_AGENT_EVENT_STREAM_ENABLED", False
             ),
+            agent_decision_mode=os.getenv("SCUT_SENIOR_AGENT_DECISION_MODE", "rule"),
             maintenance_scheduler_enabled=_env_bool(
                 "SCUT_SENIOR_MAINTENANCE_SCHEDULER_ENABLED", True
             ),
@@ -194,6 +198,10 @@ class Settings:
         if isinstance(self.agent_event_stream_enabled, bool) is False:
             raise UnsafeRuntimeConfiguration(
                 "SCUT_SENIOR_AGENT_EVENT_STREAM_ENABLED must be boolean"
+            )
+        if self.agent_decision_mode not in {"rule", "model"}:
+            raise UnsafeRuntimeConfiguration(
+                "SCUT_SENIOR_AGENT_DECISION_MODE must be rule or model"
             )
         if self.dense_retrieval_enabled and self.retrieval_mode == "local_corpus":
             if self.onnx_embedding_model_path is None:

--- a/apps/scut-senior/api/src/scut_senior_api/main.py
+++ b/apps/scut-senior/api/src/scut_senior_api/main.py
@@ -28,6 +28,7 @@ from .adapters.exam_facts import (
     FixtureExamFactsProvider,
     LocalCorpusExamFactsProvider,
 )
+from .agent_loop import ModelAgentDecision, RuleBasedAgentDecision
 from .adapters.local_corpus import LocalCorpusRetrievalGateway
 from .adapters.onnx import OnnxEmbeddingProvider
 from .adapters.mock import (
@@ -366,6 +367,11 @@ def create_app(
                 else None
             ),
         )
+    agent_decision = (
+        ModelAgentDecision(model)
+        if active_settings.agent_decision_mode == "model"
+        else RuleBasedAgentDecision()
+    )
     service = IterationZeroService(
         settings=active_settings,
         registry=registry,
@@ -383,6 +389,7 @@ def create_app(
             if active_settings.retrieval_mode == "local_corpus"
             else FixtureExamFactsProvider()
         ),
+        agent_decision=agent_decision,
     )
 
     maintenance_scheduler: MaintenanceScheduler | None = None

--- a/apps/scut-senior/api/src/scut_senior_api/service.py
+++ b/apps/scut-senior/api/src/scut_senior_api/service.py
@@ -1060,7 +1060,9 @@ class IterationZeroService:
             else workflow_focus.authoritative_query
         )
         reduce_agent(
-            "decision_produced", action=choose_next_action(agent_state, phase="retrieve")
+            "decision_produced", action=choose_next_action(
+                agent_state, phase="retrieve", workflow_type=request.workflow_type.value
+            )
         )
         interrupted = interrupt_if_step_not_claimed()
         if interrupted is not None:
@@ -1094,7 +1096,9 @@ class IterationZeroService:
                         reduce_agent(
                             "decision_produced",
                             action=choose_next_action(
-                                agent_state, phase="retrieve_with_query_rewrite"
+                                agent_state,
+                                phase="retrieve_with_query_rewrite",
+                                workflow_type=request.workflow_type.value,
                             ),
                         )
                         record_agent_action("retrieve_with_query_rewrite")
@@ -1234,7 +1238,11 @@ class IterationZeroService:
                 # for the synchronous provider call and wins at the next node.
                 reduce_agent(
                     "decision_produced",
-                    action=choose_next_action(agent_state, phase="generate"),
+                    action=choose_next_action(
+                        agent_state,
+                        phase="generate",
+                        workflow_type=request.workflow_type.value,
+                    ),
                 )
                 interrupted = interrupt_if_step_not_claimed()
                 if interrupted is not None:

--- a/apps/scut-senior/api/src/scut_senior_api/service.py
+++ b/apps/scut-senior/api/src/scut_senior_api/service.py
@@ -7,8 +7,10 @@ from uuid import UUID, uuid4
 
 from .auth import AuthRequired, AuthenticatedPrincipal, utc_now
 from .agent_loop import (
+    AgentDecisionGateway,
     AgentBudget,
     AgentState,
+    RuleBasedAgentDecision,
     choose_next_action,
     reduce_agent_event,
 )
@@ -150,6 +152,7 @@ class IterationZeroService:
         humanizer: HumanizerGateway | None = None,
         zhipu_model: ModelGateway | None = None,
         exam_facts: object | None = None,
+        agent_decision: AgentDecisionGateway | None = None,
     ):
         self.settings = settings
         self.registry = registry
@@ -165,6 +168,7 @@ class IterationZeroService:
         # Optional iteration-5 exam-review facts provider (fixture or local
         # corpus). ``None`` keeps the pre-iteration-5 behaviour exactly.
         self.exam_facts = exam_facts
+        self.agent_decision = agent_decision or RuleBasedAgentDecision()
 
     def create_conversation(
         self, user: RequestIdentity, course_id_or_alias: str
@@ -1060,8 +1064,8 @@ class IterationZeroService:
             else workflow_focus.authoritative_query
         )
         reduce_agent(
-            "decision_produced", action=choose_next_action(
-                agent_state, phase="retrieve", workflow_type=request.workflow_type.value
+            "decision_produced", action=self.agent_decision.decide(
+                request, agent_state, "retrieve", history=history
             )
         )
         interrupted = interrupt_if_step_not_claimed()
@@ -1095,10 +1099,12 @@ class IterationZeroService:
                     ):
                         reduce_agent(
                             "decision_produced",
-                            action=choose_next_action(
+                            action=self.agent_decision.decide(
+                                request,
                                 agent_state,
-                                phase="retrieve_with_query_rewrite",
-                                workflow_type=request.workflow_type.value,
+                                "retrieve_with_query_rewrite",
+                                sources=retrieval_batch.sources,
+                                history=history,
                             ),
                         )
                         record_agent_action("retrieve_with_query_rewrite")
@@ -1238,10 +1244,12 @@ class IterationZeroService:
                 # for the synchronous provider call and wins at the next node.
                 reduce_agent(
                     "decision_produced",
-                    action=choose_next_action(
+                    action=self.agent_decision.decide(
+                        request,
                         agent_state,
-                        phase="generate",
-                        workflow_type=request.workflow_type.value,
+                        "generate",
+                        sources=retrieval_batch.sources,
+                        history=history,
                     ),
                 )
                 interrupted = interrupt_if_step_not_claimed()

--- a/apps/scut-senior/tests/python/test_agent_loop.py
+++ b/apps/scut-senior/tests/python/test_agent_loop.py
@@ -23,6 +23,7 @@ def test_workflow_is_hard_boundary_for_agent_actions() -> None:
 
 def test_model_action_parser_is_fail_closed_at_workflow_boundary() -> None:
     assert parse_model_action("retrieve", workflow_type="knowledge_qa") == "retrieve"
+    assert parse_model_action("I choose retrieve", workflow_type="knowledge_qa") is None
     assert parse_model_action("retrieve_with_query_rewrite", workflow_type="temporary_material_reading") is None
     assert parse_model_action("switch_workflow", workflow_type="knowledge_qa") is None
 

--- a/apps/scut-senior/tests/python/test_agent_loop.py
+++ b/apps/scut-senior/tests/python/test_agent_loop.py
@@ -8,9 +8,16 @@ from scut_senior_api.agent_loop import (
     choose_next_action,
     record_action_result,
     record_guard_retry,
+    action_allowed_for_workflow,
     replay_agent_events,
     reduce_agent_event,
 )
+
+
+def test_workflow_is_hard_boundary_for_agent_actions() -> None:
+    assert action_allowed_for_workflow("knowledge_qa", "retrieve")
+    assert not action_allowed_for_workflow("temporary_material_reading", "retrieve_with_query_rewrite")
+    assert not action_allowed_for_workflow("unknown", "retrieve")
 
 
 def event(kind: str, **payload: object) -> dict[str, object]:

--- a/apps/scut-senior/tests/python/test_agent_loop.py
+++ b/apps/scut-senior/tests/python/test_agent_loop.py
@@ -9,6 +9,7 @@ from scut_senior_api.agent_loop import (
     record_action_result,
     record_guard_retry,
     action_allowed_for_workflow,
+    parse_model_action,
     replay_agent_events,
     reduce_agent_event,
 )
@@ -18,6 +19,12 @@ def test_workflow_is_hard_boundary_for_agent_actions() -> None:
     assert action_allowed_for_workflow("knowledge_qa", "retrieve")
     assert not action_allowed_for_workflow("temporary_material_reading", "retrieve_with_query_rewrite")
     assert not action_allowed_for_workflow("unknown", "retrieve")
+
+
+def test_model_action_parser_is_fail_closed_at_workflow_boundary() -> None:
+    assert parse_model_action("retrieve", workflow_type="knowledge_qa") == "retrieve"
+    assert parse_model_action("retrieve_with_query_rewrite", workflow_type="temporary_material_reading") is None
+    assert parse_model_action("switch_workflow", workflow_type="knowledge_qa") is None
 
 
 def event(kind: str, **payload: object) -> dict[str, object]:


### PR DESCRIPTION
<!-- obsidian --><h1 data-heading="实跑证据">实跑证据</h1>
<ul>
<li><code>6d992cc0...</code>：AB 分支最近一次成功后端运行</li>
<li><code>81ec11ae...</code>：master 最近一次成功后端运行</li>
</ul>
<h1 data-heading="输出表现">输出表现</h1>
<p>AB 输出的内容表现：</p>
<ul>
<li>复习主线清楚；</li>
<li>结合了用户大纲和历年题；</li>
<li>给了行列式、矩阵、秩、方程组、向量组、特征值和二次型的复习顺序；</li>
<li>给了具体易错点；</li>
<li>引用了 4 条历年卷资料；</li>
<li>Bilibili 关键词已经进入具体知识点，而不是只复制用户原句。<br>
主要问题：</li>
<li>总耗时很长；</li>
<li>Agent 出现了第二次生成决策；</li>
<li>发生了一次模型输出重试；</li>
<li>可见回答仍然偏长；</li>
<li>“未覆盖内容”重新复制用户大纲，带来明显冗余；</li>
<li>统计说明篇幅较大，但对用户真正的复习安排帮助有限。<br>
AB 的核心结论是：</li>
</ul>
<pre><code>证据和引用比 master 更完整，但运行过程多了一次生成重试，耗时明显更高。
</code></pre>
<p>master 输出的内容表现：</p>
<ul>
<li>同样完成了完整复习大纲；</li>
<li>章节顺序和易错点基本齐全；</li>
<li>只保留了 2 条课程引用；</li>
<li>Bilibili 关键词更具体：
<ul>
<li><code>线性代数</code></li>
<li><code>伴随矩阵求逆公式</code></li>
<li><code>线性方程组解的判定</code><br>
主要问题：</li>
</ul>
</li>
<li>也存在“未覆盖内容”复制用户大纲的问题；</li>
<li>引用数量少于 AB；</li>
<li>虽然运行更快，但供应商记录的输出 token 反而更多。</li>
</ul>
<p>master 的核心结论是：</p>
<pre><code>运行更快，没有重试，回答也能完成；
但引用覆盖少于 AB，token 用量记录反而更高。
</code></pre>
<h2 data-heading="两边直接对比">两边直接对比</h2>

指标 | AB | AB-2 | master | master-2 | 观察
-- | -- | -- | -- | -- | --
总耗时 | 84.77 秒 | 90.83秒 | 80.17 秒 | 82.59秒 | master 更快
Agent 步骤 | 6个，3步 | 5个 | 5个，2步 | 5个 | AB 多一步
生成重试 | 1 | 0 | 0 | 0 | AB 有额外成本
可见回答长度 | 5648 字符 | 5420 字符 | 5930 字符 | 6516 字符 | 基本同量级
引用数量 | 4 | 2 | 2 | 2 | AB 更多
引用接受数 | 4/5 | 2/5 | 2/5 | 2/5 | AB 更完整
Bilibili 资源 | 1 | 1 | 1 | 1 | 相同
课程越权 | 0 | 0 | 0 | 0 | 相同
证据状态 | sufficient | sufficient | sufficient | sufficient | 相同
输入 token | 4992 | 1536 | 4992 | 0 | 相同
未命中缓存 | 5098 | 3509 | 159 | 5074 | master更高
输出 token | 10541 | 10091 | 10005 | 7754 | master 更高
成本 | 0.05 | 0.05 | 0.04 | 0.04 | master 更低


<p><strong>master 的表现</strong></p>
<p>master 的回答更像“直接完成任务”：先根据考试大纲安排复习顺序，再补充行列式、矩阵、秩、线性方程组等核心公式，整体内容完整，且没有触发重试。</p>
<p>它的问题是仓库引用偏少，只有 2 条。回答虽然能用，但有一部分内容主要来自用户大纲和通用知识，历年卷证据支撑相对弱。语言也更口语化，出现了“学妹”“考完请你喝奶茶”等风格化表达，是否合适取决于你想不想保留这种陪伴式语气。</p>
<p><strong>abtest 的表现</strong></p>
<p>abtest 的回答结构更规整，明确按五个章节组织：</p>
<p><code>行列式 → 矩阵 → 秩与方程组 → 向量组 → 特征值与二次型</code></p>
<p>它还把“公式记不住”转成了“记母公式、理解公式之间的关系”，教学组织比 master 更清晰。引用数量是 master 的两倍，说明 Agent 的额外动作确实让最终回答覆盖了更多仓库依据。</p>
<p>代价也很明确：</p>
<ul>
<li>多了一步 Agent 决策；</li>
<li>发生了一次模型输出重试；</li>
<li>总耗时接近 master 的 3 倍；</li>
<li>输出 token 比 master 多约 30%；</li>
<li>花费从 0.04 元增加到 0.05 元。</li>
</ul>
<p><strong>回答质量上的共同问题</strong></p>
<p>两边都存在同一个问题：在“未覆盖内容”里重新粘贴了用户提供的大纲。这不是事实错误，但对用户价值不高，会让回答显得冗长，也会稀释真正有用的复习建议。</p>
<p>两边还都把“历年题没有按知识点完整归组”说得比较诚实，没有直接编造命题概率或“必考结论”，这一点是可靠的。</p>
<p><strong>AB 实验结论</strong></p>
<p>这次结果不是“abtest 全面胜出”，而是一个很清楚的取舍：</p>
<ul>
<li>如果优先考虑响应速度、稳定性和成本，<code>master</code> 更好。</li>
<li>如果优先考虑仓库引用覆盖和复习内容的结构化程度，<code>abtest</code> 更好。</li>
<li>Workflow 护栏在两边都正常，没有出现任务漂移、课程越权或证据状态失控。</li>
<li>abtest 的 Agent 决策机制带来了可观察的引用收益，但目前收益不足以抵消它带来的额外延迟和重试风险。</li>
</ul>
<p>我的判断是：<strong>当前不建议直接把 abtest 当成默认方案合并回 master。master 更适合作为线上基线；abtest 的“引用增强”值得保留，但需要先解决重复输出、重试导致的延迟，以及为什么一次额外决策会显著增加输出 token 的问题。</strong></p>
<p>这只是各一次运行，不能证明长期稳定性；但就这两次最新基线而言，结论已经足够明确：<strong>master 胜在效率，abtest 胜在证据覆盖，整体上 master 暂时更划算。</strong></p>