### PR TITLE
布置智能基座人员任务至实验分支

### DIFF
--- a/apps/scut-senior/README.md
+++ b/apps/scut-senior/README.md
@@ -1,6 +1,7 @@
 # SCUT 老学长
 
 SCUT 老学长是面向华南理工大学计算机相关课程的学习对话助手。应用源码、API、语料校验工具、前端、契约和测试均位于本目录。PLAN-3 已完成，应用现在同时提供单课程问答、按本次运行生效的跨课程检索、回答结果操作、公共资料贡献、用户绑定的私人知识沉淀和独立维护者审核平台。
+<img width="1536" height="1024" alt="new" src="https://github.com/user-attachments/assets/b8dadcef-1cf4-4adc-a43e-a289a2594b32" />
 
 ## 核心流程
 


### PR DESCRIPTION
当前最该做的是建立真实学生题驱动的上线回归门槛，再继续调检索。
现在已有 46 课覆盖、Hybrid 检索、受控 Workflow 和评测框架，但 330 条学生场景仍聚合到 54 个语义锚点，不能证明优化能稳定改善真实回答。应先收集独立学生问题，按课程和难度人工复核答案、证据与常见错因，再以课程宏平均和锚点分组比较候选方案。这样才能判断该优先做 reranker、题号锚点、上下文补全，还是 OCR/多模态检索。其次才是补齐三门图片型课程的 OCR 或视觉检索链路。 这也正是本期SCUT_CS仓库面向华为智能基座成员的其中人物之一